### PR TITLE
Allow setting of From Name and Email address

### DIFF
--- a/INFO
+++ b/INFO
@@ -1,10 +1,10 @@
 [info]
 name = monitor
-version = 2.3.1
+version = 2.3.2
 longname = Device Monitoring
 author = The Cacti Group
 email = 
 homepage = http://www.cacti.net
-compat = 1.1.35
+compat = 1.1.36
 requires = thold
 capabilities = online_view:1, online_mgmt:1, offline_view:0, offline_mgmt:0, remote_collect:0

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ It would be advisable to view Monitors email notification settings under Setting
 Bug and feature enhancements for the webseer plugin are handled in GitHub. If you find a first search the Cacti forums for a solution before creating an issue in GitHub.
 
 ## Changelog
+--- 2.3.2 ---
+* feature: Allow "from" email address/name to be set
+* feature: Requires a minimum of Cacti 1.1.36
+
 --- 2.3.1 ---
 * issue: fixed issue where criticalities was not being correctly referenced
 

--- a/poller_monitor.php
+++ b/poller_monitor.php
@@ -462,14 +462,20 @@ function process_email($email, $lists, $global_list, $notify_list) {
 		$v = get_cacti_version();
 		$headers['User-Agent'] = 'Cacti-Monitor-v' . $v;
 
-		$from_email = read_config_option('settings_from_email');
+		$from_email = read_config_option('monitor_formemail');
 		if ($from_email == '') {
-			$from_email = 'root@localhost';
+			$from_email = read_config_option('settings_from_email');
+			if ($from_email == '') {
+				$from_email = 'root@localhost';
+			}
 		}
 
-		$from_name  = read_config_option('settings_from_name');
-		if ($from_name == '') {
-			$from_name = 'Cacti Reporting';
+		$from_name = read_config_option('monitor_fromname');
+		if ($from_name != '') {
+			$from_name  = read_config_option('settings_from_name');
+			if ($from_name == '') {
+				$from_name = 'Cacti Reporting';
+			}
 		}
 
 		monitor_debug("Sending Email to '$email'");
@@ -490,7 +496,7 @@ function process_email($email, $lists, $global_list, $notify_list) {
 		monitor_debug("The return from the mailer was '$error'");
 
 		if (strlen($error)) {
-            cacti_log("WARNING: Monitor had problems sending Notification Report to '$email'.  The error was '$error'", false, 'MONITOR');
+			cacti_log("WARNING: Monitor had problems sending Notification Report to '$email'.  The error was '$error'", false, 'MONITOR');
 		}else{
 			cacti_log("NOTICE: Email Notification Sent to '$email' for " .
 				(sizeof($alert_hosts) ? sizeof($alert_hosts) . ' Alert Notificaitons':'') .

--- a/setup.php
+++ b/setup.php
@@ -519,6 +519,25 @@ function monitor_config_settings() {
 			'textarea_cols' => 80,
 			'default' => __('<h1>Monitor Reboot Notification</h1><p>The following Device\'s were Rebooted.  See details below for additional information.</p><br><DETAILS>', 'monitor')
 		),
+		'monitor_email_header' => array(
+			'friendly_name' => __('Notification Email Addresses', 'monitor'),
+			'method' => 'spacer',
+			'collapsible' => 'true'
+		),
+		'monitor_fromname' => array(
+			'friendly_name' => __('From Name', 'monitor'),
+			'description' => __('Enter the Email Name to send the notifications form', 'monitor'),
+			'method' => 'textbox',
+			'size' => '60',
+			'max_length' => '255'
+		),
+		'monitor_fromemail' => array(
+			'friendly_name' => __('From Address', 'monitor'),
+			'description' => __('Enter the Email Address to send the notification from', 'monitor'),
+			'method' => 'textbox',
+			'size' => '60',
+			'max_length' => '255'
+		),
 		'monitor_list' => array(
 			'friendly_name' => __('Notification List', 'thold'),
 			'description' => __('Select a Notification List below.  All Emails subscribed to the notification list will be notified.', 'thold'),


### PR DESCRIPTION
Allows the setting of the "from" name and email address. Also raises the minimum requirement to 1.1.36 as that is the lowest version with the fixed base mailer code within Cacti.