### PR TITLE
Added option to Loop the alarm sound.

### DIFF
--- a/monitor.php
+++ b/monitor.php
@@ -241,7 +241,11 @@ function draw_page() {
 	// If the host is down, we need to insert the embedded wav file
 	$monitor_sound = get_monitor_sound();
 	if (is_monitor_audible()) {
-		print "<audio id='audio' loop src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
+		if (get_monitor_sound_loop) {
+			print "<audio id='audio' loop src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
+		} else {
+			print "<audio id='audio' loop=false src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
+		}
 	}
 
 	?>
@@ -512,6 +516,10 @@ function get_monitor_sound() {
 	$file = dirname(__FILE__) . '/sounds/' . $sound;
 	$exists = file_exists($file);
 	return $exists ? $sound : '';
+}
+
+function get_monitor_sound_loop() {
+	return read_user_setting('monitor_sound_loop', read_config_option('monitor_sound_loop'));
 }
 
 function find_down_hosts() {

--- a/setup.php
+++ b/setup.php
@@ -420,6 +420,11 @@ function monitor_config_settings() {
 				'array' => monitor_scan_dir(),
 				'default' => 'attn-noc.wav',
 			),
+			'monitor_sound_loop' => array(
+				'friendly_name' => __('Loop Alarm Sound', 'monitor'),
+				'description' => __('Play the above sound on a loop when a Device goes down.', 'monitor'),
+				'method' => 'checkbox',
+			),
 			'monitor_legend' => array(
 				'friendly_name' => __('Show Icon Legend', 'monitor'),
 				'description' => __('Check this to show an icon legend on the Monitor display', 'monitor'),
@@ -458,6 +463,11 @@ function monitor_config_settings() {
 			'method' => 'drop_array',
 			'array' => monitor_scan_dir(),
 			'default' => 'attn-noc.wav',
+		),
+		'monitor_sound_loop' => array(
+			'friendly_name' => __('Loop Alarm Sound', 'monitor'),
+			'description' => __('Play the above sound on a loop when a Device goes down.', 'monitor'),
+			'method' => 'checkbox',
 		),
 		'monitor_refresh' => array(
 			'friendly_name' => __('Refresh Interval', 'monitor'),


### PR DESCRIPTION
Added the option to loop the alarm sound as it was enabled by default.

To enable the default option navigate to **Configuration** > **Settings** and click on the **Monitor** tab.
Enable the **Loop Alarm Sound** to set the default option
![image](https://user-images.githubusercontent.com/5603694/99579314-f2032f80-29d5-11eb-9479-d2603ada3052.png)

To enable or disable per user navigate to **Configuration** > **Users**
Select the required user and click on the **User Settings** tab
Scroll down to the **Monitor Settings** section
Enable the **Loop Alarm Sound** to set the sound to loop for this user when a device goes down
![image](https://user-images.githubusercontent.com/5603694/99579721-78b80c80-29d6-11eb-803c-45b21e20172f.png)
