### PR TITLE
Added option to zoom when a device is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ in GitHub.
 
 * feature: PHP 7.2 compatibility
 
+* feature#134: Added option to Loop the alarm sound
+
 --- 2.3.5 ---
 
 * feature: Support for Cacti 1.2

--- a/monitor.css
+++ b/monitor.css
@@ -351,6 +351,55 @@
 	padding: 2px;
 }
 
+// Zoom Errors Classification
+.monitor_errorzoom {
+	height: 118px;
+	width: 200px !important;
+}
+
+.monitor_errorzoom_title {
+	display: inline-block;
+	text-align: center;
+	word-wrap: break-word;
+	overflow: hidden;
+	line-height: 1.5;
+}
+
+.monitor_errorzoom_tiles {
+	height: 88px;
+	min-width: 88px;
+}
+
+.monitor_errorzoom_tilesadt {
+	height: 102px;
+	width: 128px;
+	justify-content: center;
+}
+
+.monitor_errorzoom i, .monitor_errorzoom_tiles i, .monitor_errorzoom_tilesadt i {
+	font-size: 80px;
+	min-width: 98px;
+}
+
+.monitor_errorzoom td {
+	font-size: 15px;
+}
+
+.monitor_errorzoom a, .monitor_errorzoom_tiles a, .monitor_errorzoom_tilesadt a {
+	font-size: 15px;
+	min-width: 98px;
+}
+
+.monitor_errorzoom .monitorLinkIcon {
+	font-size: 28px;
+}
+
+.monitor_device_errorzoom {
+	font-size: 10px;
+	padding: 2px;
+	min-width: 148px;
+}
+
 .monitorHover {
 	min-width: 400px;
 	max-width: 1000px;

--- a/monitor.php
+++ b/monitor.php
@@ -68,11 +68,11 @@ $icolorsdisplay = array(
 );
 
 $classes = array(
-	'monitor_exsmall' => __('Extra Small', 'monitor'),
-	'monitor_small'   => __('Small', 'monitor'),
-	'monitor_medium'  => __('Medium', 'monitor'),
-	'monitor_large'   => __('Large', 'monitor'),
-	'monitor_exlarge' => __('Extra Large', 'monitor'),
+	'monitor_exsmall'   => __('Extra Small', 'monitor'),
+	'monitor_small'     => __('Small', 'monitor'),
+	'monitor_medium'    => __('Medium', 'monitor'),
+	'monitor_large'     => __('Large', 'monitor'),
+	'monitor_exlarge'   => __('Extra Large', 'monitor'),
 	'monitor_errorzoom' => __('Zoom', 'monitor')
 );
 
@@ -191,25 +191,20 @@ function load_dashboard_settings() {
 function draw_page() {
 	global $config, $iclasses, $icolorsdisplay,$monZoomState,$dozoomrefresh,$dozoombgndcolor,$font_sizes;
 
-	$ErroredList=get_hosts_down_or_triggered_by_permission(true);
+	$ErroredList = get_hosts_down_or_triggered_by_permission(true);
 
-	if(cacti_sizeof($ErroredList) && read_user_setting('monitor_error_zoom')==true)
-	{
-		if($_SESSION['monitor_zoom_state']==0){
-		$monZoomState=$_SESSION['monitor_zoom_state']=1;
-			$_SESSION['mon_zoom_hist__status']=get_nfilter_request_var('status');
-			$_SESSION['mon_zoom_hist__size']=get_nfilter_request_var('size');
-			$dozoomrefresh=true;
-			$dozoombgndcolor=true;
+	if (cacti_sizeof($ErroredList) && read_user_setting('monitor_error_zoom') == true) {
+		if($_SESSION['monitor_zoom_state'] == 0) {
+		$monZoomState=$_SESSION['monitor_zoom_state'] = 1;
+			$_SESSION['mon_zoom_hist__status'] = get_nfilter_request_var('status');
+			$_SESSION['mon_zoom_hist__size']   = get_nfilter_request_var('size');
+			$dozoomrefresh   = true;
+			$dozoombgndcolor = true;
 		}
-	}
-	else
-	{
-		if($_SESSION['monitor_zoom_state']==1){
-			$_SESSION['monitor_zoom_state']=0;
-			$dozoomrefresh=true;
-			$dozoombgndcolor=false;
-		}
+	} elseif ($_SESSION['monitor_zoom_state']==1) {
+		$_SESSION['monitor_zoom_state'] = 0;
+		$dozoomrefresh   = true;
+		$dozoombgndcolor = false;
 	}
 
 	find_down_hosts();
@@ -273,15 +268,19 @@ function draw_page() {
 		}
 	}
 
-    if($dozoombgndcolor==true)
-	{
-		$mbcolora = db_fetch_row_prepared('SELECT * FROM colors WHERE id = ?', array(read_user_setting('monitor_error_background')));
-		$monitor_error_fontsize=read_user_setting('monitor_error_fontsize') . 'px';
-		$mbcolor="";
-		$mbcolor='#' . array_values($mbcolora)[2];
+	if ($dozoombgndcolor) {
+		$mbcolora = db_fetch_row_prepared('SELECT * 
+			FROM colors 
+			WHERE id = ?', 
+			array(read_user_setting('monitor_error_background')));
 
-		echo "<script type=\"text/javascript\">
+		$monitor_error_fontsize = read_user_setting('monitor_error_fontsize') . 'px';
+		$mbcolor = "";
+		$mbcolor = '#' . array_values($mbcolora)[2];
+
+		print "<script type=\"text/javascript\">
 			var monoe=false;
+
 			function setZoomErrorBackgrounds(){
 				$('.monitor_container').css('background-color', '$mbcolor');
 				$('.cactiConsoleContentArea').css('background-color','$mbcolor');
@@ -313,13 +312,12 @@ function draw_page() {
 				}
 			}, 600, 8);
 		</script>";
-    }
-    else{
-        echo "<script type=\"text/javascript\">
-            $('.monitor_container').css('background-color', 'white');
+	} else {
+		print "<script type=\"text/javascript\">
+			$('.monitor_container').css('background-color', 'white');
 			$('.cactiConsoleContentArea').css('background-color','white');
-            </script>";
-    }
+		</script>";
+	}
 
 	?>
 	<script type='text/javascript'>
@@ -391,8 +389,7 @@ function draw_page() {
 	}
 
 	function saveFilter() {
-		url =
-			'monitor.php?action=save&header=false' +
+		url = 'monitor.php?action=save&header=false' +
 			'&dashboard=' + $('#dashboard').val() +
 			'&refresh='   + $('#refresh').val() +
 			'&grouping='  + $('#grouping').val() +
@@ -768,34 +765,34 @@ function draw_filter_and_status() {
 		FROM plugin_monitor_dashboards
 		WHERE id = ?',
 		array(get_request_var('dashboard')));
-		$mon_zoom_status=null;
-		$mon_zoom_size=null;
-		if (isset($_SESSION['monitor_zoom_state'])) {
-			if($_SESSION['monitor_zoom_state']==1) {
-				$mon_zoom_status=2;
-				$mon_zoom_size='monitor_errorzoom';
-				$dozoombgndcolor=true;
+
+	$mon_zoom_status=null;
+	$mon_zoom_size=null;
+	if (isset($_SESSION['monitor_zoom_state'])) {
+		if ($_SESSION['monitor_zoom_state'] == 1) {
+			$mon_zoom_status = 2;
+			$mon_zoom_size   = 'monitor_errorzoom';
+			$dozoombgndcolor = true;
+		} else {
+			if (isset($_SESSION['mon_zoom_hist__status'])) {
+				$mon_zoom_status = $_SESSION['mon_zoom_hist__status'];
+			} else {
+				$mon_zoom_status = null;
 			}
-			else{
-				if (isset($_SESSION['mon_zoom_hist__status'])) {
-					$mon_zoom_status=$_SESSION['mon_zoom_hist__status'];
-				}
-				else{
-					$mon_zoom_status=null;
+
+			if (isset($_SESSION['mon_zoom_hist__size'])) {
+				$currentddsize = get_nfilter_request_var('size');
+
+				if ($currentddsize != $_SESSION['mon_zoom_hist__size'] && $currentddsize != 'monitor_errorzoom') {
+					$_SESSION['mon_zoom_hist__size'] = $currentddsize;
 				}
 
-				if (isset($_SESSION['mon_zoom_hist__size'])) {
-					$currentddsize=get_nfilter_request_var('size');
-					if($currentddsize!=$_SESSION['mon_zoom_hist__size'] && $currentddsize!='monitor_errorzoom'){
-						$_SESSION['mon_zoom_hist__size']=$currentddsize;
-					}
-					$mon_zoom_size=$_SESSION['mon_zoom_hist__size'];
-				}
-				else{
-					$mon_zoom_size=null;
-				}
+				$mon_zoom_size = $_SESSION['mon_zoom_hist__size'];
+			} else {
+				$mon_zoom_size=null;
 			}
 		}
+	}
 
 	draw_filter_dropdown('dashboard', __esc('Layout', 'monitor'), $dashboards);
 	draw_filter_dropdown('status', __esc('Status', 'monitor'), $monitor_status, $mon_zoom_status);

--- a/monitor.php
+++ b/monitor.php
@@ -72,7 +72,8 @@ $classes = array(
 	'monitor_small'   => __('Small', 'monitor'),
 	'monitor_medium'  => __('Medium', 'monitor'),
 	'monitor_large'   => __('Large', 'monitor'),
-	'monitor_exlarge' => __('Extra Large', 'monitor')
+	'monitor_exlarge' => __('Extra Large', 'monitor'),
+	'monitor_errorzoom' => __('Zoom', 'monitor')
 );
 
 $monitor_status = array(
@@ -109,6 +110,9 @@ $monitor_trim = array(
 );
 
 global $thold_hosts, $maxchars;
+
+$dozoomrefresh=false;
+$dozoombgndcolor=false;
 
 $maxchars = 12;
 
@@ -185,7 +189,28 @@ function load_dashboard_settings() {
 }
 
 function draw_page() {
-	global $config, $iclasses, $icolorsdisplay;
+	global $config, $iclasses, $icolorsdisplay,$monZoomState,$dozoomrefresh,$dozoombgndcolor,$font_sizes;
+
+	$ErroredList=get_hosts_down_or_triggered_by_permission(true);
+
+	if(cacti_sizeof($ErroredList) && read_user_setting('monitor_error_zoom')==true)
+	{
+		if($_SESSION['monitor_zoom_state']==0){
+		$monZoomState=$_SESSION['monitor_zoom_state']=1;
+			$_SESSION['mon_zoom_hist__status']=get_nfilter_request_var('status');
+			$_SESSION['mon_zoom_hist__size']=get_nfilter_request_var('size');
+			$dozoomrefresh=true;
+			$dozoombgndcolor=true;
+		}
+	}
+	else
+	{
+		if($_SESSION['monitor_zoom_state']==1){
+			$_SESSION['monitor_zoom_state']=0;
+			$dozoomrefresh=true;
+			$dozoombgndcolor=false;
+		}
+	}
 
 	find_down_hosts();
 
@@ -247,6 +272,54 @@ function draw_page() {
 			print "<audio id='audio' src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
 		}
 	}
+
+    if($dozoombgndcolor==true)
+	{
+		$mbcolora = db_fetch_row_prepared('SELECT * FROM colors WHERE id = ?', array(read_user_setting('monitor_error_background')));
+		$monitor_error_fontsize=read_user_setting('monitor_error_fontsize') . 'px';
+		$mbcolor="";
+		$mbcolor='#' . array_values($mbcolora)[2];
+
+		echo "<script type=\"text/javascript\">
+			var monoe=false;
+			function setZoomErrorBackgrounds(){
+				$('.monitor_container').css('background-color', '$mbcolor');
+				$('.cactiConsoleContentArea').css('background-color','$mbcolor');
+			};
+
+			setZoomErrorBackgrounds();
+			$('.monitor_errorzoom_title').css('font-size','$monitor_error_fontsize');
+
+			function setIntervalX(callback, delay, repetitions) {
+				var x = 0;
+				var intervalID = window.setInterval(function () {
+					callback();
+					if (++x === repetitions) {
+						window.clearInterval(intervalID);
+						setZoomErrorBackgrounds();
+					}
+				}, delay);
+			}
+
+			setIntervalX(function () {
+				if(monoe===false){
+					setZoomErrorBackgrounds();
+					monoe=true;
+				}
+				else{
+					$('.monitor_container').css('background-color', 'white');
+					$('.cactiConsoleContentArea').css('background-color','white');
+					monoe=false;
+				}
+			}, 600, 8);
+		</script>";
+    }
+    else{
+        echo "<script type=\"text/javascript\">
+            $('.monitor_container').css('background-color', 'white');
+			$('.cactiConsoleContentArea').css('background-color','white');
+            </script>";
+    }
 
 	?>
 	<script type='text/javascript'>
@@ -519,7 +592,7 @@ function get_monitor_sound() {
 }
 
 function find_down_hosts() {
-	$dhosts = get_hosts_down_or_triggered_by_permission();
+	$dhosts = get_hosts_down_or_triggered_by_permission(false);
 
 	if (cacti_sizeof($dhosts)) {
 		set_request_var('downhosts', 'true');
@@ -552,7 +625,7 @@ function unmute_up_non_triggered_hosts($dhosts) {
 }
 
 function mute_all_hosts() {
-	$_SESSION['monitor_muted_hosts'] = get_hosts_down_or_triggered_by_permission();
+	$_SESSION['monitor_muted_hosts'] = get_hosts_down_or_triggered_by_permission(false);
 	mute_user();
 }
 
@@ -668,7 +741,7 @@ function draw_filter_dropdown($id, $title, $settings = array(), $value = null) {
 }
 
 function draw_filter_and_status() {
-	global $criticalities, $page_refresh_interval, $classes, $monitor_grouping, $monitor_view_type, $monitor_status, $monitor_trim;
+	global $criticalities, $page_refresh_interval, $classes, $monitor_grouping, $monitor_view_type, $monitor_status, $monitor_trim, $dozoomrefresh, $zoomHist_Status, $zoomHist_Size, $dozoombgndcolor, $monZoomState;
 
 	$header = __('Monitor Filter [ Last Refresh: %s ]', date('g:i:s a', time()), 'monitor') . (get_request_var('refresh') < 99999 ? __(' [ Refresh Again in <i id="timer">%d</i> Seconds ]', get_request_var('refresh'), 'monitor') : '') . '<span id="text" style="vertical-align:baseline;padding:0px !important;display:none"></span>';
 
@@ -695,9 +768,37 @@ function draw_filter_and_status() {
 		FROM plugin_monitor_dashboards
 		WHERE id = ?',
 		array(get_request_var('dashboard')));
+		$mon_zoom_status=null;
+		$mon_zoom_size=null;
+		if (isset($_SESSION['monitor_zoom_state'])) {
+			if($_SESSION['monitor_zoom_state']==1) {
+				$mon_zoom_status=2;
+				$mon_zoom_size='monitor_errorzoom';
+				$dozoombgndcolor=true;
+			}
+			else{
+				if (isset($_SESSION['mon_zoom_hist__status'])) {
+					$mon_zoom_status=$_SESSION['mon_zoom_hist__status'];
+				}
+				else{
+					$mon_zoom_status=null;
+				}
+
+				if (isset($_SESSION['mon_zoom_hist__size'])) {
+					$currentddsize=get_nfilter_request_var('size');
+					if($currentddsize!=$_SESSION['mon_zoom_hist__size'] && $currentddsize!='monitor_errorzoom'){
+						$_SESSION['mon_zoom_hist__size']=$currentddsize;
+					}
+					$mon_zoom_size=$_SESSION['mon_zoom_hist__size'];
+				}
+				else{
+					$mon_zoom_size=null;
+				}
+			}
+		}
 
 	draw_filter_dropdown('dashboard', __esc('Layout', 'monitor'), $dashboards);
-	draw_filter_dropdown('status', __esc('Status', 'monitor'), $monitor_status);
+	draw_filter_dropdown('status', __esc('Status', 'monitor'), $monitor_status, $mon_zoom_status);
 	draw_filter_dropdown('view', __esc('View', 'monitor'), $monitor_view_type);
 	draw_filter_dropdown('grouping', __esc('Grouping', 'monitor'), $monitor_grouping);
 
@@ -733,7 +834,7 @@ function draw_filter_and_status() {
 	draw_filter_dropdown('crit', __('Criticality', 'monitor'), $criticalities);
 
 	if (get_request_var('view') != 'list') {
-		draw_filter_dropdown('size', __('Size', 'monitor'), $classes);
+		draw_filter_dropdown('size', __('Size', 'monitor'), $classes, $mon_zoom_size);
 	}
 
 	if (get_request_var('view') == 'default') {
@@ -817,6 +918,14 @@ function draw_filter_and_status() {
 	print '</form></td></tr>' . PHP_EOL;
 
 	html_end_box();
+
+	if($dozoomrefresh==true){
+		$dozoomrefresh=false;
+
+		echo "<script type=\"text/javascript\">
+			applyFilter('refresh');
+		</script>";
+	}
 }
 
 function get_mute_text() {
@@ -1599,7 +1708,7 @@ function get_host_status_description($status) {
 
 /*Single host  rendering */
 function render_host($host, $float = true, $maxlen = 10) {
-	global $thold_hosts, $config, $icolorsdisplay, $iclasses, $classes, $maxchars;
+	global $thold_hosts, $config, $icolorsdisplay, $iclasses, $classes, $maxchars, $monZoomState;
 
 	//throw out tree root items
 	if (array_key_exists('name', $host))  {
@@ -1632,14 +1741,27 @@ function render_host($host, $float = true, $maxlen = 10) {
 		$iclass = get_status_icon($host['status']);
 		$fclass = get_request_var('size');
 
+		$monitor_times=read_user_setting('monitor_uptime');
+		$monitor_time_html="";
+
 		if ($host['status'] <= 2 || $host['status'] == 5) {
+			if($monZoomState>0){
+				$fclass ='monitor_errorzoom';
+			}
 			$tis = get_timeinstate($host);
 
-			$result = "<div class='$fclass flash monitor_device_frame'><a class='pic hyperLink' href='" . html_escape($host['anchor']) . "'><i id='" . $host['id'] . "' class='$iclass " . $host['iclass'] . "'></i><br><div class='${fclass}_title'>" . title_trim(html_escape($host['description']), $maxlen) . "</div><br><div class='monitor_device${fclass} deviceDown'>$tis</div></a></div>";
+			if($monitor_times=='on'){
+				$monitor_time_html="<br><div class='monitor_device${fclass} deviceDown'>$tis</div>";
+			}
+			$result = "<div class='$fclass flash monitor_device_frame'><a class='pic hyperLink' href='" . html_escape($host['anchor']) . "'><i id='" . $host['id'] . "' class='$iclass " . $host['iclass'] . "'></i><br><div class='${fclass}_title'>" . title_trim(html_escape($host['description']), $maxlen) . "</div>$monitor_time_html</a></div>";
 		} else {
 			$tis = get_uptime($host);
 
-			$result = "<div class='$fclass monitor_device_frame'><a class='pic hyperLink' href='" . html_escape($host['anchor']) . "'><i id=" . $host['id'] . " class='$iclass " . $host['iclass'] . "'></i><br><div class='${fclass}_title'>" . title_trim(html_escape($host['description']), $maxlen) . "</div><br><div class='monitor_device${fclass} deviceUp'>$tis</div></a></div>";
+			if($monitor_times=='on'){
+				$monitor_time_html="<br><div class='monitor_device${fclass} deviceUp'>$tis</div>";
+			}
+
+			$result = "<div class='$fclass monitor_device_frame'><a class='pic hyperLink' href='" . html_escape($host['anchor']) . "'><i id=" . $host['id'] . " class='$iclass " . $host['iclass'] . "'></i><br><div class='${fclass}_title'>" . title_trim(html_escape($host['description']), $maxlen) . "</div>$monitor_time_html</a></div>";
 		}
 	}
 
@@ -2024,8 +2146,12 @@ function render_host_tilesadt($host, $maxlen = 10) {
 	}
 }
 
-function get_hosts_down_or_triggered_by_permission() {
+function get_hosts_down_or_triggered_by_permission($prescan) {
 	global $render_style;
+	$PreScanValue=2;
+	if($prescan){
+		$PreScanValue=3;
+	}
 
 	$result = array();
 
@@ -2074,7 +2200,7 @@ function get_hosts_down_or_triggered_by_permission() {
 	$sql_where = "h.monitor = 'on'
 		AND h.disabled = ''
 		AND h.deleted = ''
-		AND ((h.status < 2 AND (h.availability_method > 0 OR h.snmp_version > 0)) " .
+		AND ((h.status < " . $PreScanValue . " AND (h.availability_method > 0 OR h.snmp_version > 0)) " .
 		($sql_add_where != '' ? ' OR (' . $sql_add_where . '))':')');
 
 	// do a quick loop through to pull the hosts that are down

--- a/monitor.php
+++ b/monitor.php
@@ -111,8 +111,8 @@ $monitor_trim = array(
 
 global $thold_hosts, $maxchars;
 
-$dozoomrefresh=false;
-$dozoombgndcolor=false;
+$dozoomrefresh   = false;
+$dozoombgndcolor = false;
 
 $maxchars = 12;
 
@@ -301,14 +301,13 @@ function draw_page() {
 			}
 
 			setIntervalX(function () {
-				if(monoe===false){
+				if (monoe === false) {
 					setZoomErrorBackgrounds();
-					monoe=true;
-				}
-				else{
+					monoe = true;
+				} else {
 					$('.monitor_container').css('background-color', 'white');
 					$('.cactiConsoleContentArea').css('background-color','white');
-					monoe=false;
+					monoe = false;
 				}
 			}, 600, 8);
 		</script>";

--- a/monitor.php
+++ b/monitor.php
@@ -194,8 +194,8 @@ function draw_page() {
 	$ErroredList = get_hosts_down_or_triggered_by_permission(true);
 
 	if (cacti_sizeof($ErroredList) && read_user_setting('monitor_error_zoom') == true) {
-		if($_SESSION['monitor_zoom_state'] == 0) {
-		$monZoomState=$_SESSION['monitor_zoom_state'] = 1;
+		if ($_SESSION['monitor_zoom_state'] == 0) {
+			$monZoomState = $_SESSION['monitor_zoom_state'] = 1;
 			$_SESSION['mon_zoom_hist__status'] = get_nfilter_request_var('status');
 			$_SESSION['mon_zoom_hist__size']   = get_nfilter_request_var('size');
 			$dozoomrefresh   = true;

--- a/monitor.php
+++ b/monitor.php
@@ -189,7 +189,7 @@ function load_dashboard_settings() {
 }
 
 function draw_page() {
-	global $config, $iclasses, $icolorsdisplay,$monZoomState,$dozoomrefresh,$dozoombgndcolor,$font_sizes;
+	global $config, $iclasses, $icolorsdisplay, $monZoomState, $dozoomrefresh, $dozoombgndcolor, $font_sizes;
 
 	$ErroredList = get_hosts_down_or_triggered_by_permission(true);
 
@@ -765,8 +765,9 @@ function draw_filter_and_status() {
 		WHERE id = ?',
 		array(get_request_var('dashboard')));
 
-	$mon_zoom_status=null;
-	$mon_zoom_size=null;
+	$mon_zoom_status = null;
+	$mon_zoom_size   = null;
+
 	if (isset($_SESSION['monitor_zoom_state'])) {
 		if ($_SESSION['monitor_zoom_state'] == 1) {
 			$mon_zoom_status = 2;

--- a/monitor.php
+++ b/monitor.php
@@ -993,7 +993,7 @@ function validate_request_vars($force = false) {
 		'size' => array(
 			'filter' => FILTER_CALLBACK,
 			'options' => array('options' => 'sanitize_search_string'),
-			'default' => read_user_setting('monitor_size', 'monior_medium', $force)
+			'default' => read_user_setting('monitor_size', 'monitor_medium', $force)
 		),
 		'trim' => array(
 			'filter' => FILTER_VALIDATE_INT,

--- a/monitor.php
+++ b/monitor.php
@@ -241,7 +241,7 @@ function draw_page() {
 	// If the host is down, we need to insert the embedded wav file
 	$monitor_sound = get_monitor_sound();
 	if (is_monitor_audible()) {
-		if (get_monitor_sound_loop) {
+		if (get_monitor_sound_loop()) {
 			print "<audio id='audio' loop src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
 		} else {
 			print "<audio id='audio' loop=false src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";

--- a/monitor.php
+++ b/monitor.php
@@ -241,10 +241,10 @@ function draw_page() {
 	// If the host is down, we need to insert the embedded wav file
 	$monitor_sound = get_monitor_sound();
 	if (is_monitor_audible()) {
-		if (get_monitor_sound_loop()) {
+		if (read_user_setting('monitor_sound_loop', read_config_option('monitor_sound_loop'))) {
 			print "<audio id='audio' loop src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
 		} else {
-			print "<audio id='audio' loop=false src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
+			print "<audio id='audio' src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
 		}
 	}
 
@@ -516,10 +516,6 @@ function get_monitor_sound() {
 	$file = dirname(__FILE__) . '/sounds/' . $sound;
 	$exists = file_exists($file);
 	return $exists ? $sound : '';
-}
-
-function get_monitor_sound_loop() {
-	return read_user_setting('monitor_sound_loop', read_config_option('monitor_sound_loop'));
 }
 
 function find_down_hosts() {

--- a/monitor.php
+++ b/monitor.php
@@ -241,7 +241,11 @@ function draw_page() {
 	// If the host is down, we need to insert the embedded wav file
 	$monitor_sound = get_monitor_sound();
 	if (is_monitor_audible()) {
-		print "<audio id='audio' loop src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
+		if (get_monitor_sound_loop) {
+			print "<audio id='audio' loop src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
+		} else {
+			print "<audio id='audio' loop=false src='" . html_escape($config['url_path'] . 'plugins/monitor/sounds/' . $monitor_sound) . "'></audio>";
+		}
 	}
 
 	?>
@@ -512,6 +516,10 @@ function get_monitor_sound() {
 	$file = dirname(__FILE__) . '/sounds/' . $sound;
 	$exists = file_exists($file);
 	return $exists ? $sound : '';
+}
+
+function get_monitor_sound_loop() {
+	return read_user_setting('monitor_sound_loop', read_config_option('monitor_sound_loop'));
 }
 
 function find_down_hosts() {

--- a/setup.php
+++ b/setup.php
@@ -405,6 +405,15 @@ function monitor_config_settings() {
 		'365' => __('%d Year', 1, 'monitor')
 	);
 
+	$font_sizes=array(
+		'20'=>'20px',
+		'30'=>'30px',
+		'40'=>'40px',
+		'50'=>'50px',
+		'60'=>'60px',
+		'70'=>'70px'
+	);
+
 	if (function_exists('auth_augment_roles')) {
 		auth_augment_roles(__('Normal User'), array('monitor.php'));
 	}
@@ -429,6 +438,28 @@ function monitor_config_settings() {
 				'friendly_name' => __('Show Icon Legend', 'monitor'),
 				'description' => __('Check this to show an icon legend on the Monitor display', 'monitor'),
 				'method' => 'checkbox',
+			),
+			'monitor_uptime' => array(
+				'friendly_name' => __('Show Uptime', 'monitor'),
+				'description' => __('Check this to show Uptime on the Monitor display', 'monitor'),
+				'method' => 'checkbox',
+			),
+			'monitor_error_zoom' => array(
+				'friendly_name' => __('Zoom to Errors', 'monitor'),
+				'description' => __('Check this to zoom to errored items on the Monitor display', 'monitor'),
+				'method' => 'checkbox',
+			),
+			'monitor_error_background' => array(
+				'friendly_name' => __('Zoom Background', 'monitor'),
+				'description' => __('Background Color for Zoomed Errors on the Monitor display', 'monitor'),
+				'method' => 'drop_color',
+			),
+			'monitor_error_fontsize' => array(
+				'friendly_name' => __('Zoom Fontsize', 'monitor'),
+				'description' => __('Check this to zoom to errored items on the Monitor display', 'monitor'),
+				'method' => 'drop_array',
+				'default' => '50',
+				'array' => $font_sizes
 			)
 		)
 	);

--- a/setup.php
+++ b/setup.php
@@ -420,6 +420,11 @@ function monitor_config_settings() {
 				'array' => monitor_scan_dir(),
 				'default' => 'attn-noc.wav',
 			),
+			'monitor_sound_loop' => array(
+				'friendly_name' => __('Loop Alarm Sound', 'monitor'),
+				'description' => __('Play the above sound on a loop when a Device goes down.', 'monitor'),
+				'method' => 'checkbox',
+			),
 			'monitor_legend' => array(
 				'friendly_name' => __('Show Icon Legend', 'monitor'),
 				'description' => __('Check this to show an icon legend on the Monitor display', 'monitor'),
@@ -458,6 +463,11 @@ function monitor_config_settings() {
 			'method' => 'drop_array',
 			'array' => monitor_scan_dir(),
 			'default' => 'attn-noc.wav',
+		),
+		'monitor_sound_loop' => array(
+			'friendly_name' => __('Loop Alarm Sound', 'monitor'),
+			'description' => __('Play the above sound on a loop when a Device goes down.', 'monitor'),
+			'method' => 'checkbox',
 		),
 		'monitor_refresh' => array(
 			'friendly_name' => __('Refresh Interval', 'monitor'),


### PR DESCRIPTION
This will allow you (per user) to set the screen to zoom in and only show the devices are down.
Very helpful if used with wallboards so all staff can easily see what devices are down.
You can also set the background colour when devices are down to help alert staff of issues.

When devices come back up it will automatically go back to the layout you had previously.

This is a per user setting and the options are in the users profile.
The default behaviour is to stay the same as before this option was added.