### PR TITLE
extend email subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * feature: Support the new Drop Icon form object in Cacti
 * feature: Support for Cacti 1.3
 * featture#186: New table view - Names only
+* feature: Better email subject if Send one Email to all addresses is on
 
 --- 2.8 ---
 

--- a/poller_monitor.php
+++ b/poller_monitor.php
@@ -357,10 +357,16 @@ function process_reboot_email($email, $hosts) {
 	$body .= '</table>' . PHP_EOL;
 
 	$subject = read_config_option('monitor_subject');
-
 	$monitor_send_one_email = read_config_option('monitor_send_one_email');
+
 	if ($monitor_send_one_email == 'on') {
 		$subject .= ' ' . $host['description'] . ' (' . $host['hostname'] . ')';
+	} else {
+		if (cacti_sizeof($hosts) == 1) {
+			$subject .= ' 1 device  - ' . $host['description'] . ' (' . $host['hostname'] . ')';
+		} else {
+			$subject .= ' ' . cacti_sizeof($hosts) . ' devices';
+		}
 	}
 
 	$output  = read_config_option('monitor_body');


### PR DESCRIPTION
It is confusing when "Send one Email to all addresses" is enabled and user get email with only one device in subject.