### PR TITLE
refactor: DRY monitor action render wrapper

### DIFF
--- a/monitor.php
+++ b/monitor.php
@@ -130,6 +130,7 @@ if (!isset($_SESSION['monitor_muted_hosts'])) {
 
 include_once __DIR__ . '/db_functions.php';
 include_once __DIR__ . '/monitor_render.php';
+include_once __DIR__ . '/monitor_helpers.php';
 include_once __DIR__ . '/monitor_controller.php';
 
 validateRequestVars();
@@ -142,28 +143,23 @@ switch (get_nfilter_request_var('action')) {
 
 		break;
 	case 'ajax_mute_all':
-		muteAllHosts();
-		drawPage();
+		monitorRunActionAndRender('muteAllHosts');
 
 		break;
 	case 'ajax_unmute_all':
-		unmuteAllHosts();
-		drawPage();
+		monitorRunActionAndRender('unmuteAllHosts');
 
 		break;
 	case 'dbchange':
-		loadDashboardSettings();
-		drawPage();
+		monitorRunActionAndRender('loadDashboardSettings');
 
 		break;
 	case 'remove':
-		removeDashboard();
-		drawPage();
+		monitorRunActionAndRender('removeDashboard');
 
 		break;
 	case 'saveDb':
-		saveSettings();
-		drawPage();
+		monitorRunActionAndRender('saveSettings');
 
 		break;
 	case 'save':

--- a/monitor_helpers.php
+++ b/monitor_helpers.php
@@ -10,19 +10,29 @@ declare(strict_types = 1);
  | modify it under the terms of the GNU General Public License             |
  | as published by the Free Software Foundation; either version 2          |
  | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDTool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
  +-------------------------------------------------------------------------+
  */
 
-if (!function_exists('monitorRunActionAndRender')) {
-	/**
-	 * Execute one monitor action callback and then render the monitor page.
-	 *
-	 * @param callable $action Action callback with no arguments.
-	 *
-	 * @return void
-	 */
-	function monitorRunActionAndRender(callable $action): void {
-		call_user_func($action);
-		drawPage();
-	}
+/**
+ * Execute one monitor action callback and then render the monitor page.
+ *
+ * @param callable $action Action callback with no arguments.
+ *
+ * @return void
+ */
+function monitorRunActionAndRender(callable $action): void {
+	$action();
+	drawPage();
 }

--- a/monitor_helpers.php
+++ b/monitor_helpers.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
+if (!function_exists('monitorRunActionAndRender')) {
+	/**
+	 * Execute one monitor action callback and then render the monitor page.
+	 *
+	 * @param callable $action Action callback with no arguments.
+	 *
+	 * @return void
+	 */
+	function monitorRunActionAndRender(callable $action): void {
+		call_user_func($action);
+		drawPage();
+	}
+}

--- a/tests/test_action_render_wrapper.php
+++ b/tests/test_action_render_wrapper.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
 require_once __DIR__ . '/../monitor_helpers.php';
 
 $events = [];
@@ -23,6 +34,13 @@ function assert_same($expected, $actual, string $message): void {
 	}
 }
 
+function assert_regex(string $pattern, string $subject, string $message): void {
+	if (!preg_match($pattern, $subject)) {
+		fwrite(STDERR, $message . PHP_EOL);
+		exit(1);
+	}
+}
+
 monitorRunActionAndRender('monitor_test_action');
 assert_same(['action', 'render'], $events, 'Wrapper should run action before render.');
 
@@ -32,19 +50,17 @@ if ($source === false) {
 	exit(1);
 }
 
-$expected_calls = [
-	"monitorRunActionAndRender('muteAllHosts');",
-	"monitorRunActionAndRender('unmuteAllHosts');",
-	"monitorRunActionAndRender('loadDashboardSettings');",
-	"monitorRunActionAndRender('removeDashboard');",
-	"monitorRunActionAndRender('saveSettings');"
+$expected_patterns = [
+	"/include_once\\s+__DIR__\\s*\\.\\s*'\\/monitor_helpers\\.php'\\s*;/",
+	"/monitorRunActionAndRender\\(\\s*'muteAllHosts'\\s*\\)\\s*;/",
+	"/monitorRunActionAndRender\\(\\s*'unmuteAllHosts'\\s*\\)\\s*;/",
+	"/monitorRunActionAndRender\\(\\s*'loadDashboardSettings'\\s*\\)\\s*;/",
+	"/monitorRunActionAndRender\\(\\s*'removeDashboard'\\s*\\)\\s*;/",
+	"/monitorRunActionAndRender\\(\\s*'saveSettings'\\s*\\)\\s*;/"
 ];
 
-foreach ($expected_calls as $expected_call) {
-	if (strpos($source, $expected_call) === false) {
-		fwrite(STDERR, "Expected monitor.php to call wrapper: $expected_call\n");
-		exit(1);
-	}
+foreach ($expected_patterns as $expected_pattern) {
+	assert_regex($expected_pattern, $source, "Expected monitor.php to match pattern: $expected_pattern");
 }
 
 echo "OK\n";

--- a/tests/test_action_render_wrapper.php
+++ b/tests/test_action_render_wrapper.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once __DIR__ . '/../monitor_helpers.php';
+
+$events = [];
+
+function drawPage(): void {
+	global $events;
+	$events[] = 'render';
+}
+
+function monitor_test_action(): void {
+	global $events;
+	$events[] = 'action';
+}
+
+function assert_same($expected, $actual, string $message): void {
+	if ($expected !== $actual) {
+		fwrite(STDERR, $message . PHP_EOL);
+		fwrite(STDERR, 'Expected: ' . json_encode($expected) . PHP_EOL);
+		fwrite(STDERR, 'Actual:   ' . json_encode($actual) . PHP_EOL);
+		exit(1);
+	}
+}
+
+monitorRunActionAndRender('monitor_test_action');
+assert_same(['action', 'render'], $events, 'Wrapper should run action before render.');
+
+$source = file_get_contents(__DIR__ . '/../monitor.php');
+if ($source === false) {
+	fwrite(STDERR, "Unable to read monitor.php\n");
+	exit(1);
+}
+
+$expected_calls = [
+	"monitorRunActionAndRender('muteAllHosts');",
+	"monitorRunActionAndRender('unmuteAllHosts');",
+	"monitorRunActionAndRender('loadDashboardSettings');",
+	"monitorRunActionAndRender('removeDashboard');",
+	"monitorRunActionAndRender('saveSettings');"
+];
+
+foreach ($expected_calls as $expected_call) {
+	if (strpos($source, $expected_call) === false) {
+		fwrite(STDERR, "Expected monitor.php to call wrapper: $expected_call\n");
+		exit(1);
+	}
+}
+
+echo "OK\n";


### PR DESCRIPTION
## Summary
Implements issue #205 by consolidating repeated monitor action handling that performs an action and then renders the page.

### Changes
- added shared helper `monitorRunActionAndRender()` in `monitor_helpers.php`
- updated `monitor.php` to route repeated action paths through helper:
  - `ajax_mute_all`
  - `ajax_unmute_all`
  - `dbchange`
  - `remove`
  - `saveDb`
- added standalone regression test: `tests/test_action_render_wrapper.php`

## Validation
- `php -l monitor.php`
- `php -l monitor_helpers.php`
- `php -l tests/test_action_render_wrapper.php`
- `php tests/test_action_render_wrapper.php`

## Issue
Closes #205
