### PR TITLE
security: fix RLIKE SQLi, XSS, integer casting, and dynamic dispatch

### DIFF
--- a/db_functions.php
+++ b/db_functions.php
@@ -96,21 +96,21 @@ function renderGroupConcat(string &$sql_where, string $sql_join, string $sql_fie
  */
 function renderWhereJoin(string &$sql_where, string &$sql_join): void {
 	if (get_request_var('crit') > 0) {
-		$awhere = 'h.monitor_criticality >= ' . get_request_var('crit');
+		$awhere = 'h.monitor_criticality >= ' . (int) get_request_var('crit');
 	} else {
 		$awhere = '';
 	}
 
 	if (get_request_var('grouping') == 'site') {
 		if (get_request_var('site') > 0) {
-			$awhere .= ($awhere == '' ? '' : ' AND ') . 'h.site_id = ' . get_request_var('site');
+			$awhere .= ($awhere == '' ? '' : ' AND ') . 'h.site_id = ' . (int) get_request_var('site');
 		} elseif (get_request_var('site') == -2) {
 			$awhere .= ($awhere == '' ? '' : ' AND ') . ' h.site_id = 0';
 		}
 	}
 
 	if (get_request_var('rfilter') != '') {
-		$awhere .= ($awhere == '' ? '' : ' AND ') . " h.description RLIKE '" . get_request_var('rfilter') . "'";
+		$awhere .= ($awhere == '' ? '' : ' AND ') . ' h.description RLIKE ' . db_qstr(get_request_var('rfilter'));
 	}
 
 	if (get_request_var('grouping') == 'tree') {

--- a/monitor_controller.php
+++ b/monitor_controller.php
@@ -106,7 +106,9 @@ function drawPage(): void {
 
 	// Default with permissions = default_by_permission
 	// Tree  = group_by_tree
-	$function = 'render' . ucfirst(get_request_var('grouping'));
+	$allowed_groupings = ['default', 'tree', 'site', 'template'];
+	$grouping          = in_array(get_request_var('grouping'), $allowed_groupings, true) ? get_request_var('grouping') : 'default';
+	$function          = 'render' . ucfirst($grouping);
 
 	if (function_exists($function) && get_request_var('view') != 'list') {
 		if (get_request_var('grouping') == 'default' || get_request_var('grouping') == 'site') {
@@ -548,23 +550,23 @@ function monitorRenderGroupingDropdowns(array $classes, array $criticalities, ar
  */
 function monitorRenderHiddenFilterInputs(): void {
 	if (get_request_var('grouping') != 'tree') {
-		print '<td><input type="hidden" id="tree" value="' . get_request_var('tree') . '"></td>' . PHP_EOL;
+		print '<td><input type="hidden" id="tree" value="' . html_escape(get_request_var('tree')) . '"></td>' . PHP_EOL;
 	}
 
 	if (get_request_var('grouping') != 'site') {
-		print '<td><input type="hidden" id="site" value="' . get_request_var('site') . '"></td>' . PHP_EOL;
+		print '<td><input type="hidden" id="site" value="' . html_escape(get_request_var('site')) . '"></td>' . PHP_EOL;
 	}
 
 	if (get_request_var('grouping') != 'template') {
-		print '<td><input type="hidden" id="template" value="' . get_request_var('template') . '"></td>' . PHP_EOL;
+		print '<td><input type="hidden" id="template" value="' . html_escape(get_request_var('template')) . '"></td>' . PHP_EOL;
 	}
 
 	if (get_request_var('view') == 'list') {
-		print '<td><input type="hidden" id="size" value="' . get_request_var('size') . '"></td>' . PHP_EOL;
+		print '<td><input type="hidden" id="size" value="' . html_escape(get_request_var('size')) . '"></td>' . PHP_EOL;
 	}
 
 	if (get_request_var('view') != 'default') {
-		print '<td><input type="hidden" id="trim" value="' . get_request_var('trim') . '"></td>' . PHP_EOL;
+		print '<td><input type="hidden" id="trim" value="' . html_escape(get_request_var('trim')) . '"></td>' . PHP_EOL;
 	}
 }
 

--- a/poller_functions.php
+++ b/poller_functions.php
@@ -317,8 +317,8 @@ function buildRebootDetails(array $hosts): array {
 
 		$last_host = $host;
 		$body .= '<tr>' .
-			'<td class="left">' . $host['description'] . '</td>' .
-			'<td class="left">' . $host['hostname'] . '</td>' .
+			'<td class="left">' . html_escape($host['description']) . '</td>' .
+			'<td class="left">' . html_escape($host['hostname']) . '</td>' .
 			'</tr>' . PHP_EOL;
 
 		$body_txt .=


### PR DESCRIPTION
## Summary

- Fix RLIKE SQL injection in `db_functions.php:113` by using `db_qstr()` instead of string concatenation. Guest-accessible when `$guest_account=true`.
- Add `html_escape()` to 5 hidden input value attributes in `monitor_controller.php` to prevent reflected XSS
- Add `html_escape()` to host description/hostname in email notification body (`poller_functions.php`) to prevent stored XSS via SNMP
- Add `(int)` cast to `crit` and `site` request vars before SQL concatenation as defense-in-depth
- Add allowlist validation (`default`, `tree`, `site`, `template`) for the `grouping` parameter before dynamic function dispatch

## Test plan

- [ ] Verify monitor dashboard loads with all grouping modes (default, tree, site, template)
- [ ] Verify filter/search works on the monitor page
- [ ] Verify email notifications render device names correctly
- [ ] Verify hidden form fields preserve values during page interactions