### PR TITLE
fix(sql): migrate interpolated queries to prepared statements

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -319,9 +319,9 @@ function monitor_device_action_execute($action) {
 }
 
 function monitor_device_remove($devices) {
-	db_execute('DELETE FROM plugin_monitor_notify_history WHERE host_id IN(' . implode(',', $devices) . ')');
-	db_execute('DELETE FROM plugin_monitor_reboot_history WHERE host_id IN(' . implode(',', $devices) . ')');
-	db_execute('DELETE FROM plugin_monitor_uptime WHERE host_id IN(' . implode(',', $devices) . ')');
+	db_execute_prepared('DELETE FROM plugin_monitor_notify_history WHERE host_id IN(' . implode(',', array_fill(0, cacti_count($devices), '?')) . ')', array_values(array_map('intval', $devices)));
+	db_execute_prepared('DELETE FROM plugin_monitor_reboot_history WHERE host_id IN(' . implode(',', array_fill(0, cacti_count($devices), '?')) . ')', array_values(array_map('intval', $devices)));
+	db_execute_prepared('DELETE FROM plugin_monitor_uptime WHERE host_id IN(' . implode(',', array_fill(0, cacti_count($devices), '?')) . ')', array_values(array_map('intval', $devices)));
 
 	return $devices;
 }


### PR DESCRIPTION
Migrate remaining non-prepared SQL queries that interpolate PHP variables to use prepared statement variants (db_execute_prepared, db_fetch_cell_prepared, etc.). Static SQL without variable interpolation is left as-is.