### PR TITLE
Avoid monitor JavaScript redeclaration errors

### DIFF
--- a/js/monitor.js
+++ b/js/monitor.js
@@ -1,13 +1,13 @@
-let refreshMSeconds = 99999999;
-let myTimer;
+var refreshMSeconds = 99999999;
+var myTimer;
 
-const monitorCfg = globalThis.monitorPageConfig || {};
-const mbColor = monitorCfg.mbColor || '';
-const monitorFont = monitorCfg.monitorFont || '10px';
-const dozoomRefresh = Boolean(monitorCfg.doZoomRefresh);
-const monitorMessages = monitorCfg.messages || {};
-const monitorNewForm = monitorCfg.newForm || '';
-const monitorNewTitle = monitorCfg.newTitle || '';
+var monitorCfg = globalThis.monitorPageConfig || {};
+var mbColor = monitorCfg.mbColor || '';
+var monitorFont = monitorCfg.monitorFont || '10px';
+var dozoomRefresh = Boolean(monitorCfg.doZoomRefresh);
+var monitorMessages = monitorCfg.messages || {};
+var monitorNewForm = monitorCfg.newForm || '';
+var monitorNewTitle = monitorCfg.newTitle || '';
 
 function setZoomErrorBackgrounds() {
 	if (mbColor !== '') {


### PR DESCRIPTION
This PR updates top-level declarations in `js/monitor.js` from `let` / `const` to `var`.

The Monitor page can reload content through AJAX. When `monitor.js` is executed more than once, top-level `let` / `const` declarations can throw JavaScript redeclaration errors, such as:

`Uncaught SyntaxError: Identifier 'refreshMSeconds' has already been declared`

This can prevent Monitor dropdowns and filter controls from applying changes correctly after an AJAX reload.

This change keeps block-scoped declarations inside functions unchanged and only adjusts the top-level declarations that may be executed more than once.

Fixes #220

Tested:
- Verified the Monitor page no longer throws the `refreshMSeconds` redeclaration error
- Verified Monitor dropdown/filter controls continue working after AJAX reload
- Verified `git diff --check` returns no whitespace errors