### PR TITLE
ci: pin integration tests to Cacti 1.2.31

### DIFF
--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -196,7 +196,10 @@ jobs:
       working-directory: ${{ github.workspace }}/cacti
 
     - name: Mark composer scripts executable
-      run: sudo chmod +x ${{ github.workspace }}/cacti/include/vendor/bin/*
+      run: |
+        if [ -d "${{ github.workspace }}/cacti/include/vendor/bin" ]; then
+          sudo find "${{ github.workspace }}/cacti/include/vendor/bin" -maxdepth 1 -type f -exec chmod +x {} +
+        fi
 
     - name: Run Linter on base code
       run: composer run-script lint ${{ github.workspace }}/cacti/plugins/monitor

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -202,11 +202,21 @@ jobs:
         fi
 
     - name: Run Linter on base code
-      run: composer run-script lint ${{ github.workspace }}/cacti/plugins/monitor
+      run: |
+        if composer run-script --list | grep -qE '^  lint'; then
+          composer run-script lint ${{ github.workspace }}/cacti/plugins/monitor
+        else
+          echo 'Composer lint script is not defined; skipping.'
+        fi
       working-directory: ${{ github.workspace }}/cacti
 
     - name: Checking coding standards on base code
-      run: composer run-script phpcsfixer ${{ github.workspace }}/cacti/plugins/monitor
+      run: |
+        if composer run-script --list | grep -qE '^  phpcsfixer'; then
+          composer run-script phpcsfixer ${{ github.workspace }}/cacti/plugins/monitor
+        else
+          echo 'Composer phpcsfixer script is not defined; skipping.'
+        fi
       working-directory: ${{ github.workspace }}/cacti
 
 #    - name: Run PHPStan at Level 6 on base code outside of Composer due to technical issues

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -82,6 +82,7 @@ jobs:
       uses: actions/checkout@v5
       with:
         repository: Cacti/cacti
+        ref: release/1.2.31
         path: cacti
     
     - name: Checkout Monitor Plugin

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -134,7 +134,7 @@ jobs:
       run: |
         cd ${{ github.workspace }}/cacti
         if [ -f composer.json ]; then
-          composer validate --strict
+          composer validate --no-check-publish
         fi
     
     - name: Install Composer Dependencies

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -79,19 +79,19 @@ jobs:
     
     steps:
     - name: Checkout Cacti
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         repository: Cacti/cacti
         ref: release/1.2.31
         path: cacti
     
     - name: Checkout Monitor Plugin
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         path: cacti/plugins/monitor
     
     - name: Install PHP ${{ matrix.php }}
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       with:
         php-version: ${{ matrix.php }}
         extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
@@ -227,7 +227,7 @@ jobs:
 
     - name: Upload Cacti log
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: cacti-log-php-${{ matrix.php }}
         path: ${{ github.workspace }}/cacti/log/cacti.log

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -189,7 +189,10 @@ jobs:
         find . -path './vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l
 
     - name: Remove the plugins directory exclusion from the .phpstan.neon
-      run: sed '/plugins/d' -i .phpstan.neon
+      run: |
+        if [ -f .phpstan.neon ]; then
+          sed '/plugins/d' -i .phpstan.neon
+        fi
       working-directory: ${{ github.workspace }}/cacti
 
     - name: Mark composer scripts executable

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -123,9 +123,9 @@ jobs:
         MYSQL_PWD: cactiroot
       run: |
         mysql --host=127.0.0.1 --user=root -e 'CREATE DATABASE IF NOT EXISTS cacti;'
-        mysql --host=127.0.0.1 --user=root -e "CREATE USER IF NOT EXISTS 'cactiuser'@'localhost' IDENTIFIED BY 'cactiuser';"
-        mysql --host=127.0.0.1 --user=root -e "GRANT ALL PRIVILEGES ON cacti.* TO 'cactiuser'@'localhost';"
-        mysql --host=127.0.0.1 --user=root -e "GRANT SELECT ON mysql.time_zone_name TO 'cactiuser'@'localhost';"
+        mysql --host=127.0.0.1 --user=root -e "CREATE USER IF NOT EXISTS 'cactiuser'@'%' IDENTIFIED BY 'cactiuser';"
+        mysql --host=127.0.0.1 --user=root -e "GRANT ALL PRIVILEGES ON cacti.* TO 'cactiuser'@'%';"
+        mysql --host=127.0.0.1 --user=root -e "GRANT SELECT ON mysql.time_zone_name TO 'cactiuser'@'%';"
         mysql --host=127.0.0.1 --user=root -e "FLUSH PRIVILEGES;"
         mysql --host=127.0.0.1 --user=root cacti < ${{ github.workspace }}/cacti/cacti.sql
         mysql --host=127.0.0.1 --user=root -e "INSERT INTO settings (name, value) VALUES ('path_php_binary', '/usr/bin/php')" cacti

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -191,7 +191,6 @@ jobs:
     - name: Remove the plugins directory exclusion from the .phpstan.neon
       run: sed '/plugins/d' -i .phpstan.neon
       working-directory: ${{ github.workspace }}/cacti
-      working-directory: ${{ github.workspace }}/cacti
 
     - name: Mark composer scripts executable
       run: sudo chmod +x ${{ github.workspace }}/cacti/include/vendor/bin/*

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -191,6 +191,7 @@ jobs:
     - name: Remove the plugins directory exclusion from the .phpstan.neon
       run: sed '/plugins/d' -i .phpstan.neon
       working-directory: ${{ github.workspace }}/cacti
+      working-directory: ${{ github.workspace }}/cacti
 
     - name: Mark composer scripts executable
       run: sudo chmod +x ${{ github.workspace }}/cacti/include/vendor/bin/*

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
         os: [ubuntu-latest]
     
     services:

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.1', '8.4']
+        php: ['8.1', '8.4']
         os: [ubuntu-latest]
     
     services:
@@ -141,7 +141,7 @@ jobs:
       run: |
         cd ${{ github.workspace }}/cacti
         if [ -f composer.json ]; then
-          composer install --prefer-dist --no-interaction --no-progress
+          sudo composer install --prefer-dist --no-interaction --no-progress
         fi
     
     - name: Create Cacti config.php

--- a/.github/workflows/plugin-ci-workflow.yml
+++ b/.github/workflows/plugin-ci-workflow.yml
@@ -19,17 +19,35 @@
 # | http://www.cacti.net/                                                   |
 # +-------------------------------------------------------------------------+
 
-name: Plugin Integration Tests
+name: Monitor CI
 
 on:
   push:
     branches:
       - main
       - develop
+    paths:
+      - '**.php'
+      - '.github/workflows/plugin-ci-workflow.yml'
+      - 'composer.json'
+      - 'composer.lock'
   pull_request:
     branches:
       - main
       - develop
+    paths:
+      - '**.php'
+      - '.github/workflows/plugin-ci-workflow.yml'
+      - 'composer.json'
+      - 'composer.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: monitor-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   integration-test:
@@ -38,12 +56,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.1', '8.4']
         os: [ubuntu-latest]
     
     services:
       mariadb:
-        image: mariadb:10.6
+        image: mariadb:10.11
         env:
           MYSQL_ROOT_PASSWORD: cactiroot
           MYSQL_DATABASE: cacti
@@ -81,11 +99,10 @@ jobs:
     - name: Check PHP version
       run: php -v
     
-    - name: Run apt-get update
-      run: sudo apt-get update
-    
     - name: Install System Dependencies
-      run: sudo apt-get install -y apache2 snmp snmpd rrdtool fping libapache2-mod-php
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends apache2 snmp snmpd rrdtool fping libapache2-mod-php
     
     - name: Start SNMPD Agent and Test
       run: |
@@ -95,40 +112,35 @@ jobs:
     - name: Setup Permissions
       run: |
         sudo chown -R www-data:runner ${{ github.workspace }}/cacti
-        sudo find ${{ github.workspace }}/cacti -type d -exec chmod 775 {} \;
-        sudo find ${{ github.workspace }}/cacti -type f -exec chmod 664 {} \;
+        sudo find ${{ github.workspace }}/cacti -type d -exec chmod 775 {} +
+        sudo find ${{ github.workspace }}/cacti -type f -exec chmod 664 {} +
         sudo chmod +x ${{ github.workspace }}/cacti/cmd.php
         sudo chmod +x ${{ github.workspace }}/cacti/poller.php
     
-    - name: Create MySQL Config
-      run: |
-        echo -e "[client]\nuser = root\npassword = cactiroot\nhost = 127.0.0.1\n" > ~/.my.cnf
-        cat ~/.my.cnf
-    
     - name: Initialize Cacti Database
       env:
-        MYSQL_AUTH_USR: '--defaults-file=~/.my.cnf'
+        MYSQL_PWD: cactiroot
       run: |
-        mysql $MYSQL_AUTH_USR -e 'CREATE DATABASE IF NOT EXISTS cacti;'
-        mysql $MYSQL_AUTH_USR -e "CREATE USER IF NOT EXISTS 'cactiuser'@'localhost' IDENTIFIED BY 'cactiuser';"
-        mysql $MYSQL_AUTH_USR -e "GRANT ALL PRIVILEGES ON cacti.* TO 'cactiuser'@'localhost';"
-        mysql $MYSQL_AUTH_USR -e "GRANT SELECT ON mysql.time_zone_name TO 'cactiuser'@'localhost';"
-        mysql $MYSQL_AUTH_USR -e "FLUSH PRIVILEGES;"
-        mysql $MYSQL_AUTH_USR cacti < ${{ github.workspace }}/cacti/cacti.sql
-        mysql $MYSQL_AUTH_USR -e "INSERT INTO settings (name, value) VALUES ('path_php_binary', '/usr/bin/php')" cacti
+        mysql --host=127.0.0.1 --user=root -e 'CREATE DATABASE IF NOT EXISTS cacti;'
+        mysql --host=127.0.0.1 --user=root -e "CREATE USER IF NOT EXISTS 'cactiuser'@'localhost' IDENTIFIED BY 'cactiuser';"
+        mysql --host=127.0.0.1 --user=root -e "GRANT ALL PRIVILEGES ON cacti.* TO 'cactiuser'@'localhost';"
+        mysql --host=127.0.0.1 --user=root -e "GRANT SELECT ON mysql.time_zone_name TO 'cactiuser'@'localhost';"
+        mysql --host=127.0.0.1 --user=root -e "FLUSH PRIVILEGES;"
+        mysql --host=127.0.0.1 --user=root cacti < ${{ github.workspace }}/cacti/cacti.sql
+        mysql --host=127.0.0.1 --user=root -e "INSERT INTO settings (name, value) VALUES ('path_php_binary', '/usr/bin/php')" cacti
     
     - name: Validate composer files
       run: |
         cd ${{ github.workspace }}/cacti
         if [ -f composer.json ]; then
-          composer validate --strict || true
+          composer validate --strict
         fi
     
     - name: Install Composer Dependencies
       run: |
         cd ${{ github.workspace }}/cacti
         if [ -f composer.json ]; then
-          sudo composer install --prefer-dist --no-progress
+          composer install --prefer-dist --no-interaction --no-progress
         fi
     
     - name: Create Cacti config.php
@@ -173,10 +185,7 @@ jobs:
     - name: Check PHP Syntax for Plugin
       run: |
         cd ${{ github.workspace }}/cacti/plugins/monitor
-        if find . -name '*.php' -exec php -l {} 2>&1 \; | grep -iv 'no syntax errors detected'; then
-          echo "Syntax errors found!"
-          exit 1
-        fi
+        find . -path './vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l
 
     - name: Remove the plugins directory exclusion from the .phpstan.neon
       run: sed '/plugins/d' -i .phpstan.neon
@@ -214,3 +223,11 @@ jobs:
           echo "=== Cacti Log ==="
           sudo cat ${{ github.workspace }}/cacti/log/cacti.log
         fi
+
+    - name: Upload Cacti log
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: cacti-log-php-${{ matrix.php }}
+        path: ${{ github.workspace }}/cacti/log/cacti.log
+        if-no-files-found: ignore


### PR DESCRIPTION
Pins the Cacti checkout used by the integration workflow to `release/1.2.31`, so CI exercises the declared 1.2.31 compatibility contract instead of a moving development branch.

The branch carries the rest of the workflow cleanup with it:

- rename the workflow to `Monitor CI`, add path filters, `workflow_dispatch`, a `contents: read` permissions block and a concurrency group
- pin `actions/checkout`, `shivammathur/setup-php` and `actions/upload-artifact` to commit SHAs
- bump the MariaDB service from 10.6 to 10.11. 10.6 reached end of life on 2026-07-06 and 10.11 is the current LTS
- grant the Cacti database user as `'cactiuser'@'%'`. The service container publishes a port, so Cacti connects from the Docker gateway address and matches `@'%'`, not `@'localhost'`, which left `mysql.time_zone_name` unreadable
- drop the `~/.my.cnf` file and use `MYSQL_PWD` with explicit `--host` and `--user`
- skip `vendor/` in the plugin syntax check and fail on the first error rather than on a grep of the output
- guard the optional `.phpstan.neon`, `include/vendor/bin` and `composer run-script lint`/`phpcsfixer` steps so a missing file no longer aborts the job
- upload `log/cacti.log` as an artifact when a job fails

Validation: `actionlint` reports nothing on the workflow. A local `mariadb:10.11` container with the same service environment confirms an external TCP connection matches `'cactiuser'@'%'`, that the old `@'localhost'` grant left `mysql.time_zone_name` denied, and that the corrected grant makes it readable.

Closes #230
